### PR TITLE
Update Intro markup, improve links

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -1,25 +1,25 @@
-# Programming Psychological Experiments using python and OpenSesame (academic year 2022-2023) 
+# Programming Psychological Experiments using Python and OpenSesame (academic year 2022-2023) 
 
-Welcome to this JupyterBook, which provides the course material covered partially in the course [Experimentation I: Programming Psychological Experiments](https://studiegids.universiteitleiden.nl/en/courses/114580/experimentation-i-programming-psychological-experiments). This course is part of the [research master program in Psychology](https://www.universiteitleiden.nl/en/education/study-programmes/master/psychology-research) at [Leiden University](http://leidenuniv.nl/) in the Netherlands.
+Welcome to this JupyterBook, which provides the course material covered partially in the course [Experimentation I: Programming Psychological Experiments](https://studiegids.universiteitleiden.nl/en/courses/114580/experimentation-i-programming-psychological-experiments). This course is part of the [research master program in Psychology](https://www.universiteitleiden.nl/en/education/study-programmes/master/psychology-research) at [Leiden University](https://www.universiteitleiden.nl/en) in the Netherlands.
 
-Using this material, you can learn how to code in python, build experiments using OpenSesame, and do basic data preprocessing in python. Like the software packages we will be using, all of the material in this course is open and freely available. Please note that the compiled JupyterBook is a collection of teaching material from various sources, and it heavily relies on and integrates earlier work generously provided by others online. We always acknowledge the work of these contributors whenever we use their material. The major contributors are mentioned below.
+Using this material, you can learn how to code in Python, build experiments using OpenSesame, and do basic data preprocessing in Python. Like the software packages we will be using, all of the material in this course is open and freely available. Please note that the compiled JupyterBook is a collection of teaching material from various sources, and it heavily relies on and integrates earlier work generously provided by others online. We always acknowledge the work of these contributors whenever we use their material. The major contributors are mentioned below.
 
 ## How to use this material?
 
 Make sure you save your work in a well-organized folder structure. Some of the later exercises build on work you did earlier during the course.
 
-We have provided solutions to all exercises [here](https://jeshuat.github.io/Experimentation1/content/solutions_book/solutions.html). Just keep in mind that there are often multiple ways to solve a problem, so if you come up with a different solution, that doesn't necessarily mean you're wrong. Don't forget that figuring out how to solve a problem on your own is an important part of the learning process and can be incredibly fulfilling. Embrace the challenge and take pride in your ability to find solutions independently!
+We have provided [solutions to all exercises](https://jeshuat.github.io/Experimentation1/content/solutions_book/solutions.html). Just keep in mind that there are often multiple ways to solve a problem, so if you come up with a different solution, that doesn't necessarily mean you're wrong. Don't forget that figuring out how to solve a problem on your own is an important part of the learning process and can be incredibly fulfilling. Embrace the challenge and take pride in your ability to find solutions independently!
 
 - If you're taking this course in-person at Leiden University: This course material is partially covered in an intensive eight-week course at Leiden University, where you will participate in practical sessions to receive live feedback and help. No prior programming knowledge is assumed. We expect that you have read/watched the lessons at home. During the practical sessions, you will then work through the python exercises, the OpenSesame tutorials, and the subsequent exercises in class.
 
 
-- If you're teaching yourself: We understand that it can be challenging to self-teach python and OpenSesame, and you may need help from a more experienced classmate or colleague, particularly during the exercises. If you are interested in having a similar course organized by us at your institute, please feel free to [contact us](mailto:HvanSteenbergen@fsw.leidenuniv.nl) to discuss possibilities.
+- If you're teaching yourself: We understand that it can be challenging to self-teach Python and OpenSesame, and you may need help from a more experienced classmate or colleague, particularly during the exercises. If you are interested in having a similar course organized by us at your institute, please feel free to [contact us](mailto:HvanSteenbergen@fsw.leidenuniv.nl) to discuss possibilities.
 
 ## Acknowledgements
 
-Our course is a renewed version of an [earlier course](https://studiegids.universiteitleiden.nl/en/courses/110025/experimentation-i-programming-psychological-experiments) that Henk led at Leiden University for over a decade. This course focused on E-Prime and accompanied the book [The E-Primer](https://www.e-primer.com/), which was written together with Michiel Spape, Rinus Verdonschot, and Saskia van Dantzig, my esteemed colleagues at Leiden University in the early days. Although the current course is much more focused on coding than the previous course, we still owe a lot of inspiration from the earlier book and even have reused parts of this book in the current course. Our initial discussions with Dirk van Morselaar (VU Amsterdam) were also really influential and helped us to make python coding a central part of this course.
+Our course is a renewed version of an [earlier course](https://studiegids.universiteitleiden.nl/en/courses/110025/experimentation-i-programming-psychological-experiments) that Henk led at Leiden University for over a decade. This course focused on E-Prime and accompanied the book [The E-Primer](https://www.e-primer.com/), which was written together with Michiel Spape, Rinus Verdonschot, and Saskia van Dantzig, my esteemed colleagues at Leiden University in the early days. Although the current course is much more focused on coding than the previous course, we still owe a lot of inspiration from the earlier book and even have reused parts of this book in the current course. Our initial discussions with Dirk van Morselaar (VU Amsterdam) were also really influential and helped us to make Python coding a central part of this course.
 
-Additionally, many of the lessons and python exercises in this course are based on the ["Python for Everyone" course](www.py4e.com) provided by Charles R. Severance. We are grateful for the opportunity to integrate his open material into this course.
+Additionally, many of the lessons and python exercises in this course are based on the ["Python for Everyone" course](https://www.py4e.com) provided by Charles R. Severance. We are grateful for the opportunity to integrate his open material into this course.
 
 Some of the OpenSesame tutorials in this course directly come from the [OpenSesame website](https://osdoc.cogsci.nl/) developed and maintained by Sebastian Mathot and his colleagues. We thank Sebastian for his help and the useful advice he provided.
 
@@ -35,7 +35,7 @@ Last but not least, we are grateful to the board of the faculty of Social and Be
 
 *author and workgroup instructor*
 
-**Dr. Henk van Steenbergen, Associate Professor and PI at the [Affect, Motivation and Action lab](http://www.henkvansteenbergen.com)**
+**Dr. Henk van Steenbergen, Associate Professor and PI at the [Affect, Motivation and Action lab](https://www.henkvansteenbergen.com)**
 
 *author and course coordinator*
 


### PR DESCRIPTION
These are minor edits to the introduction of the course text.

- Use a capital P in Python
- use heading markup instead of bold text for heading texts
- replace 'here' as link text with a summary of the linked page
- use HTTPS URLs for all links

I hope this is helpful!